### PR TITLE
Change docs to use permit/restrict as needed in newer versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ How it works:
 * You add a new dependency to your project and send it out for review in a pull request
 * License Approval detects the new dependency and finds the license
   * For completeness License Approval checks transitive dependencies as well
-* If License Approval finds any license that isn't on the whitelist, it will block the pull request
+* If License Approval finds any license that isn't on the permitted list, it will block the pull request
 * Your team can review the license or consult with your legal team to determine if the license is acceptable
-* Finally you can add the license to the whitelist or blacklist as needed
+* Finally you can add the license to the permitted list or restricted list as needed.
 
 This project relies heavily on [pivotal/LicenseFinder](https://github.com/pivotal/LicenseFinder). Be sure to review their docs as well.
 
@@ -46,7 +46,7 @@ This indicates that the tool doesn't know if the `MIT`, `Simplified BSD`, and `r
 
 You can mark the MIT license as acceptable by running:
 
-    license_finder whitelist add MIT
+    license_finder permitted_licenses add MIT
 
 Now any `MIT` licensed dependencies will automatically be approved.
 


### PR DESCRIPTION
License Finder no longer uses whitelist/blacklist. Updated docs with the new terms.

https://github.com/pivotal/LicenseFinder/tree/master#upgrading