### PR TITLE
feat: add working directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,11 +8,16 @@ inputs:
     description: 'Which package manager to check (comma separated)'
     required: true
     default: 'bundler'
+  working_directory:
+    default: '/'
+    description: "Which directory to check"
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-  - ${{ inputs.package_manager }}
+    - ${{ inputs.package_manager }}
+    - ${{ inputs.working_directory }}
 branding:
-  icon: 'file-text'  
+  icon: 'file-text'
   color: 'purple'

--- a/script.sh
+++ b/script.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-cd "$GITHUB_WORKSPACE"
+WORKSPACE=`echo "$GITHUB_WORKSPACE/$2" | sed -e 's,//,/,g'`
+
+cd "$WORKSPACE"
 
 if [ -f Gemfile.lock ]; then
 	# Install matching bundler version for max compatibility
@@ -24,4 +26,3 @@ if [ "$?" -ne 0 ]; then
 fi
 
 license_finder
-


### PR DESCRIPTION
Adding a new optional parameter `working_directory`, so that the license check can also be run in a subdirectory of a repository. 

A sanitizing for double slashes is done in the shell script. 