### PR TITLE
Support non-`bundler` package managers

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -17,12 +17,16 @@ if [ -f Gemfile.lock ]; then
 	fi
 fi
 
-# Make sure dependencies are installed
-bundle install
-if [ "$?" -ne 0 ]; then
-	echo "Failed to install dependencies"
-	echo "Try to pre-install these before calling this action"
-	exit 1
+PACKAGE_MANAGER="${1}"
+
+if [ "${PACKAGE_MANAGER}" == "bundler" ]; then
+	# Make sure dependencies are installed
+	bundle install
+	if [ "$?" -ne 0 ]; then
+		echo "Failed to install dependencies"
+		echo "Try to pre-install these before calling this action"
+		exit 1
+	fi
 fi
 
 license_finder


### PR DESCRIPTION
Instead of hardcoding/requiring `bundler`, allow the upstream detection, as per:

>By default, license_finder will check for all supported package managers
>-- https://github.com/pivotal/LicenseFinder#narrow-down-package-manager